### PR TITLE
Set default values for bootstrap

### DIFF
--- a/.buildkite/bootstrap.yml
+++ b/.buildkite/bootstrap.yml
@@ -16,6 +16,7 @@ steps:
       - text: "Buildkite org slug"
         key: "org_slug"
         required: true
+        default: "bootstrap-example"
         hint: "Find it in your URL: buildkite.com/<org-slug>"
       
       # Registry name - will create a package registry for Docker images
@@ -23,7 +24,7 @@ steps:
       - text: "Registry name"
         key: "registry"
         required: true
-        default: "internal"
+        default: "bootstrap-example"
         hint: "Name for your package registry (must be unique)"
       
       # Hosted agent configuration - determines the compute resources
@@ -80,9 +81,9 @@ steps:
           # Export Terraform variables from the form inputs
           # These are retrieved from Buildkite metadata (set by the block step)
           echo "--- :key: Setting up Terraform variables"
-          export TF_VAR_org_slug="$(buildkite-agent meta-data get org_slug)"
-          export TF_VAR_registry_name="$(buildkite-agent meta-data get registry)"
-          export TF_VAR_queue_shape="$(buildkite-agent meta-data get shape)"
+          export TF_VAR_org_slug="$(buildkite-agent meta-data get org_slug || echo bootstrap-example)"
+          export TF_VAR_registry_name="$(buildkite-agent meta-data get registry || echo bootstrap-example)"
+          export TF_VAR_queue_shape="$(buildkite-agent meta-data get shape || echo LINUX_AMD64_2X4)"
           export TF_VAR_buildkite_api_token="$(buildkite-agent meta-data get bk_token)"
           
           # Initialize Terraform - downloads providers and sets up backend
@@ -144,9 +145,9 @@ steps:
           
           # Set up Terraform variables (must match plan step exactly)
           echo "--- :key: Setting up Terraform variables"
-          export TF_VAR_org_slug="$(buildkite-agent meta-data get org_slug)"
-          export TF_VAR_registry_name="$(buildkite-agent meta-data get registry)"
-          export TF_VAR_queue_shape="$(buildkite-agent meta-data get shape)"
+          export TF_VAR_org_slug="$(buildkite-agent meta-data get org_slug || echo bootstrap-example)"
+          export TF_VAR_registry_name="$(buildkite-agent meta-data get registry || echo bootstrap-example)"
+          export TF_VAR_queue_shape="$(buildkite-agent meta-data get shape || echo LINUX_AMD64_2X4)"
           export TF_VAR_buildkite_api_token="$(buildkite-agent meta-data get bk_token)"
           
           # Apply the infrastructure changes

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ All the heavy lifting is done by **Terraform**, executed from inside Buildkite.
 1. **Fork** this repo into your GitHub organisation.
 2. In Buildkite, click **“New pipeline → GitHub → nodejs-example-bootstrap”**.  
    Make sure the pipeline **YAML steps** path is `.buildkite/bootstrap.yml`.
-3. **First build starts** and shows an **Interactive Block**.  
+3. **First build starts** and shows an **Interactive Block**.
    Fill out:
-   * **Buildkite organisation slug** (e.g. `acme-corp`)
-   * **Registry name** (default `acme-internal`)
+   * **Buildkite organisation slug** (default `bootstrap-example`)
+   * **Registry name** (default `bootstrap-example`)
    * **Hosted‑agent shape** (`LINUX_AMD64_2X4` etc.)
    * **Org‑level API token** with _write_ scope
 4. Click **“Unblock”** → Terraform `plan` runs.  

--- a/debug.sh
+++ b/debug.sh
@@ -29,8 +29,8 @@ echo ""
 read -p "Buildkite org slug [bootstrap-example]: " ORG_SLUG
 ORG_SLUG=${ORG_SLUG:-bootstrap-example}
 
-read -p "Registry name [bootstrap-registry]: " REGISTRY_NAME
-REGISTRY_NAME=${REGISTRY_NAME:-bootstrap-registry}
+read -p "Registry name [bootstrap-example]: " REGISTRY_NAME
+REGISTRY_NAME=${REGISTRY_NAME:-bootstrap-example}
 
 read -p "Queue shape [LINUX_AMD64_2X4]: " QUEUE_SHAPE
 QUEUE_SHAPE=${QUEUE_SHAPE:-LINUX_AMD64_2X4}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,7 +14,7 @@ variable "org_slug" {
 variable "registry_name" {
   type        = string
   description = "Name for the package registry"
-  default     = "bootstrap-registry"
+  default     = "bootstrap-example"
 }
 
 variable "queue_shape" {


### PR DESCRIPTION
## Summary
- add default values for `org_slug` and `registry` in bootstrap pipeline
- provide fallback values when exporting Terraform vars
- update debug helper script default registry name
- change terraform variable default for registry name
- update README quick-start instructions

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853654b69208331a1c3705605a1e075