### PR TITLE
Fix Terraform chdir path

### DIFF
--- a/.buildkite/bootstrap.yml
+++ b/.buildkite/bootstrap.yml
@@ -88,12 +88,12 @@ steps:
           
           # Initialize Terraform - downloads providers and sets up backend
           echo "--- :terraform: Initializing Terraform"
-          terraform -chdir=terraform init -input=false
+          terraform -chdir=/workdir/terraform init -input=false
           
           # Create execution plan and save it to a file
           # This plan will be applied in the next step if approved
           echo "--- :terraform: Planning infrastructure changes"
-          terraform -chdir=terraform plan -input=false -out=../artifacts/terraform.tfplan
+          terraform -chdir=/workdir/terraform plan -input=false -out=../artifacts/terraform.tfplan
           
           # Display the plan in human-readable format for review
           echo "--- :mag: Showing planned changes"
@@ -151,8 +151,8 @@ steps:
           
           # Apply the infrastructure changes
           echo "--- :terraform: Applying infrastructure changes"
-          terraform -chdir=terraform init -input=false # Re-initialize to ensure consistency
-          terraform -chdir=terraform apply -input=false -auto-approve ../artifacts/terraform.tfplan
+          terraform -chdir=/workdir/terraform init -input=false # Re-initialize to ensure consistency
+          terraform -chdir=/workdir/terraform apply -input=false -auto-approve ../artifacts/terraform.tfplan
           
           echo "--- :white_check_mark: Infrastructure deployed successfully!"
           


### PR DESCRIPTION
## Summary
- use absolute path for Terraform steps in bootstrap.yml

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68538a29aec48331a999d52b08f5a91a