### PR TITLE
Fix Terraform chdir path

### DIFF
--- a/.buildkite/bootstrap.yml
+++ b/.buildkite/bootstrap.yml
@@ -58,6 +58,11 @@ steps:
         # Create a directory to store artifacts that will be passed between steps
         # This ensures the terraform plan file can be uploaded and downloaded
         mkdir -p artifacts
+
+        echo "--- :debug: Host working directory"
+        pwd
+        ls -al
+        ls -al terraform || true
         
         # Run Terraform inside a Docker container for consistency
         # This ensures the same Terraform version is used regardless of the agent
@@ -70,7 +75,12 @@ steps:
           --volume $(command -v buildkite-agent):/usr/bin/buildkite-agent \
           --entrypoint /bin/sh \
           hashicorp/terraform:1.5.7 \
-          -c 'set -euo pipefail
+          -c 'set -euxo pipefail
+
+          echo "--- :debug: Inside container"
+          pwd
+          ls -al
+          ls -al terraform || true
           
           # Install required Alpine Linux packages
           # curl: needed for GraphQL API calls to create registry/analytics
@@ -88,12 +98,13 @@ steps:
           
           # Initialize Terraform - downloads providers and sets up backend
           echo "--- :terraform: Initializing Terraform"
-          terraform -chdir=terraform init -input=false
+          cd terraform
+          terraform init -input=false
           
           # Create execution plan and save it to a file
           # This plan will be applied in the next step if approved
           echo "--- :terraform: Planning infrastructure changes"
-          terraform -chdir=terraform plan -input=false -out=../artifacts/terraform.tfplan
+          terraform plan -input=false -out=../artifacts/terraform.tfplan
           
           # Display the plan in human-readable format for review
           echo "--- :mag: Showing planned changes"
@@ -125,7 +136,12 @@ steps:
         # Download the terraform plan from the previous step
         # This ensures we apply exactly what was shown in the plan
         buildkite-agent artifact download "artifacts/terraform.tfplan" .
-        
+
+        echo "--- :debug: Host working directory"
+        pwd
+        ls -al
+        ls -al terraform || true
+
         # Run Terraform apply in Docker (same setup as plan step)
         docker run --rm \
           --volume "$PWD:/workdir" \
@@ -136,7 +152,12 @@ steps:
           --volume $(command -v buildkite-agent):/usr/bin/buildkite-agent \
           --entrypoint /bin/sh \
           hashicorp/terraform:1.5.7 \
-          -c 'set -euo pipefail
+          -c 'set -euxo pipefail
+
+          echo "--- :debug: Inside container"
+          pwd
+          ls -al
+          ls -al terraform || true
           
           # Install dependencies (same as plan step)
           echo "--- :package: Installing dependencies"
@@ -151,8 +172,9 @@ steps:
           
           # Apply the infrastructure changes
           echo "--- :terraform: Applying infrastructure changes"
-          terraform -chdir=terraform init -input=false # Re-initialize to ensure consistency
-          terraform -chdir=terraform apply -input=false -auto-approve ../artifacts/terraform.tfplan
+          cd terraform
+          terraform init -input=false # Re-initialize to ensure consistency
+          terraform apply -input=false -auto-approve ../artifacts/terraform.tfplan
           
           echo "--- :white_check_mark: Infrastructure deployed successfully!"
           


### PR DESCRIPTION
## Summary
- add debug info when running Terraform
- run Terraform inside terraform directory instead of using `-chdir`

## Testing
- `npm --prefix app install`
- `npm --prefix app test`

------
https://chatgpt.com/codex/tasks/task_e_68538a29aec48331a999d52b08f5a91a