### PR TITLE
Fix terraform plan pathing

### DIFF
--- a/.buildkite/bootstrap.yml
+++ b/.buildkite/bootstrap.yml
@@ -63,11 +63,14 @@ steps:
         pwd
         ls -al
         ls -al terraform || true
-        
+
+        HOST_DIR="${BUILDKITE_BUILD_CHECKOUT_PATH:-$PWD}"
+        echo "--- :debug: Using HOST_DIR=$HOST_DIR"
+
         # Run Terraform inside a Docker container for consistency
         # This ensures the same Terraform version is used regardless of the agent
         docker run --rm \
-          --volume "$PWD:/workdir" \
+          --volume "$HOST_DIR:/workdir" \
           --workdir /workdir \
           --env BUILDKITE_JOB_ID \
           --env BUILDKITE_BUILD_ID \
@@ -76,6 +79,8 @@ steps:
           --entrypoint /bin/sh \
           hashicorp/terraform:1.5.7 \
           -c 'set -euo pipefail
+
+          cd /workdir
 
           set -x
 
@@ -102,17 +107,17 @@ steps:
           
           # Initialize Terraform - downloads providers and sets up backend
           echo "--- :terraform: Initializing Terraform"
-          terraform -chdir=/workdir/terraform init -input=false
+          terraform -chdir=./terraform init -input=false
           
           # Create execution plan and save it to a file
           # This plan will be applied in the next step if approved
           echo "--- :terraform: Planning infrastructure changes"
 
-          terraform -chdir=/workdir/terraform plan -input=false -out=/workdir/artifacts/terraform.tfplan
+          terraform -chdir=./terraform plan -input=false -out=/workdir/artifacts/terraform.tfplan
           
           # Display the plan in human-readable format for review
           echo "--- :mag: Showing planned changes"
-          terraform -chdir=/workdir/terraform show -no-color /workdir/artifacts/terraform.tfplan'
+          terraform -chdir=./terraform show -no-color /workdir/artifacts/terraform.tfplan'
     
     # Upload the plan file as a build artifact
     # This allows the apply step to download and use the exact same plan
@@ -146,9 +151,12 @@ steps:
         ls -al
         ls -al terraform || true
 
+        HOST_DIR="${BUILDKITE_BUILD_CHECKOUT_PATH:-$PWD}"
+        echo "--- :debug: Using HOST_DIR=$HOST_DIR"
+
         # Run Terraform apply in Docker (same setup as plan step)
         docker run --rm \
-          --volume "$PWD:/workdir" \
+          --volume "$HOST_DIR:/workdir" \
           --workdir /workdir \
           --env BUILDKITE_JOB_ID \
           --env BUILDKITE_BUILD_ID \
@@ -157,6 +165,8 @@ steps:
           --entrypoint /bin/sh \
           hashicorp/terraform:1.5.7 \
           -c 'set -euo pipefail
+
+          cd /workdir
 
           set -x
 
@@ -180,15 +190,15 @@ steps:
           
           # Apply the infrastructure changes
           echo "--- :terraform: Applying infrastructure changes"
-          terraform -chdir=/workdir/terraform init -input=false # Re-initialize to ensure consistency
-          terraform -chdir=/workdir/terraform apply -input=false -auto-approve /workdir/artifacts/terraform.tfplan
+          terraform -chdir=./terraform init -input=false # Re-initialize to ensure consistency
+          terraform -chdir=./terraform apply -input=false -auto-approve /workdir/artifacts/terraform.tfplan
           
           echo "--- :white_check_mark: Infrastructure deployed successfully!"
           
           # Save Terraform outputs for reference
           # This might include cluster IDs, registry URLs, etc.
           echo "--- :floppy_disk: Saving outputs"
-          terraform -chdir=/workdir/terraform output -json > /workdir/artifacts/terraform-outputs.json'
+          terraform -chdir=./terraform output -json > /workdir/artifacts/terraform-outputs.json'
     
     # Upload outputs as artifacts for debugging/reference
     artifact_paths:


### PR DESCRIPTION
## Summary
- use Buildkite checkout path when mounting repo
- show which path is mounted for easier debugging

## Testing
- `npm install --prefix app`
- `npm test --prefix app`


------
https://chatgpt.com/codex/tasks/task_e_685390c0d8e08331b0baa17a108f5441