### PR TITLE
Fix HOST_DIR path for Terraform steps

### DIFF
--- a/.buildkite/bootstrap.yml
+++ b/.buildkite/bootstrap.yml
@@ -64,7 +64,7 @@ steps:
         ls -al
         ls -al terraform || true
 
-        HOST_DIR="${BUILDKITE_BUILD_CHECKOUT_PATH:-$PWD}"
+        HOST_DIR="$PWD"
         echo "--- :debug: Using HOST_DIR=$HOST_DIR"
 
         # Run Terraform inside a Docker container for consistency
@@ -151,7 +151,7 @@ steps:
         ls -al
         ls -al terraform || true
 
-        HOST_DIR="${BUILDKITE_BUILD_CHECKOUT_PATH:-$PWD}"
+        HOST_DIR="$PWD"
         echo "--- :debug: Using HOST_DIR=$HOST_DIR"
 
         # Run Terraform apply in Docker (same setup as plan step)


### PR DESCRIPTION
## Summary
- set HOST_DIR to current directory for terraform plan and apply steps

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853947c218883318f7d2cf2e104099f